### PR TITLE
feat: add correlation and idempotency intent options

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ config = AxmeClientConfig(
 
 with AxmeClient(config) as client:
     print(client.health())
+    result = client.create_intent(
+        {
+            "intent_type": "notify.message.v1",
+            "from_agent": "agent://example/sender",
+            "to_agent": "agent://example/receiver",
+            "payload": {"text": "hello"},
+        },
+        correlation_id="11111111-1111-1111-1111-111111111111",
+        idempotency_key="create-intent-001",
+    )
+    print(result)
 ```
 
 ## Development


### PR DESCRIPTION
## Summary
- update `create_intent` to require `correlation_id` and support optional `idempotency_key`
- enforce correlation consistency when payload already includes `correlation_id`
- expand tests and README example for retry-safe write flows

## Test plan
- [x] `/home/georgebelsky/axme-workspace/repos/axme/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)