### PR TITLE
feat: add inbox list, thread, and reply client methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ with AxmeClient(config) as client:
         idempotency_key="create-intent-001",
     )
     print(result)
+    inbox = client.list_inbox(owner_agent="agent://example/receiver")
+    print(inbox)
+    replied = client.reply_inbox_thread(
+        "11111111-1111-4111-8111-111111111111",
+        message="Acknowledged",
+        owner_agent="agent://example/receiver",
+        idempotency_key="reply-001",
+    )
+    print(replied)
 ```
 
 ## Development

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -65,3 +65,45 @@ class AxmeClient:
         if response.status_code >= 400:
             raise AxmeHttpError(response.status_code, response.text)
         return response.json()
+
+    def list_inbox(self, *, owner_agent: str | None = None) -> dict[str, Any]:
+        params: dict[str, str] | None = None
+        if owner_agent is not None:
+            params = {"owner_agent": owner_agent}
+        response = self._http.get("/v1/inbox", params=params)
+        if response.status_code >= 400:
+            raise AxmeHttpError(response.status_code, response.text)
+        return response.json()
+
+    def get_inbox_thread(self, thread_id: str, *, owner_agent: str | None = None) -> dict[str, Any]:
+        params: dict[str, str] | None = None
+        if owner_agent is not None:
+            params = {"owner_agent": owner_agent}
+        response = self._http.get(f"/v1/inbox/{thread_id}", params=params)
+        if response.status_code >= 400:
+            raise AxmeHttpError(response.status_code, response.text)
+        return response.json()
+
+    def reply_inbox_thread(
+        self,
+        thread_id: str,
+        *,
+        message: str,
+        owner_agent: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] | None = None
+        if owner_agent is not None:
+            params = {"owner_agent": owner_agent}
+        headers: dict[str, str] | None = None
+        if idempotency_key is not None:
+            headers = {"Idempotency-Key": idempotency_key}
+        response = self._http.post(
+            f"/v1/inbox/{thread_id}/reply",
+            params=params,
+            json={"message": message},
+            headers=headers,
+        )
+        if response.status_code >= 400:
+            raise AxmeHttpError(response.status_code, response.text)
+        return response.json()


### PR DESCRIPTION
## Summary
- implement `list_inbox`, `get_inbox_thread`, and `reply_inbox_thread` in the Python SDK
- support owner-scoped inbox operations and idempotency header on reply writes
- extend tests and quickstart docs for Track C inbox/reply parity

## Test plan
- [x] `/home/georgebelsky/axme-workspace/repos/axme/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)