### PR TITLE
feat: add typed HTTP errors and inbox changes pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ with AxmeClient(config) as client:
     print(result)
     inbox = client.list_inbox(owner_agent="agent://example/receiver")
     print(inbox)
+    changes = client.list_inbox_changes(owner_agent="agent://example/receiver", limit=50)
+    print(changes["next_cursor"], changes["has_more"])
     replied = client.reply_inbox_thread(
         "11111111-1111-4111-8111-111111111111",
         message="Acknowledged",

--- a/axme_sdk/__init__.py
+++ b/axme_sdk/__init__.py
@@ -1,9 +1,20 @@
 from .client import AxmeClient, AxmeClientConfig
-from .exceptions import AxmeError, AxmeHttpError
+from .exceptions import (
+    AxmeAuthError,
+    AxmeError,
+    AxmeHttpError,
+    AxmeRateLimitError,
+    AxmeServerError,
+    AxmeValidationError,
+)
 
 __all__ = [
     "AxmeClient",
     "AxmeClientConfig",
+    "AxmeAuthError",
     "AxmeError",
     "AxmeHttpError",
+    "AxmeRateLimitError",
+    "AxmeServerError",
+    "AxmeValidationError",
 ]

--- a/axme_sdk/exceptions.py
+++ b/axme_sdk/exceptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 
 class AxmeError(Exception):
     """Base SDK exception."""
@@ -8,7 +10,36 @@ class AxmeError(Exception):
 class AxmeHttpError(AxmeError):
     """Raised for non-success Axme API responses."""
 
-    def __init__(self, status_code: int, message: str) -> None:
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        *,
+        body: Any | None = None,
+        request_id: str | None = None,
+        trace_id: str | None = None,
+        retry_after: int | None = None,
+    ) -> None:
         super().__init__(f"HTTP {status_code}: {message}")
         self.status_code = status_code
         self.message = message
+        self.body = body
+        self.request_id = request_id
+        self.trace_id = trace_id
+        self.retry_after = retry_after
+
+
+class AxmeAuthError(AxmeHttpError):
+    """Authentication or authorization failure."""
+
+
+class AxmeValidationError(AxmeHttpError):
+    """Request/contract validation failure."""
+
+
+class AxmeRateLimitError(AxmeHttpError):
+    """Rate limit exceeded."""
+
+
+class AxmeServerError(AxmeHttpError):
+    """Unexpected server-side failure."""


### PR DESCRIPTION
## Summary
- map HTTP status codes to typed Python SDK exceptions (`auth`, `validation`, `rate limit`, `server`)
- add `list_inbox_changes` with owner/cursor/limit pagination parameters
- update tests and README examples for typed errors and pagination usage

## Test plan
- [x] `/home/georgebelsky/axme-workspace/repos/axme/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)