### PR TITLE
feat: add approvals and capabilities methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ with AxmeClient(config) as client:
         idempotency_key="reply-001",
     )
     print(replied)
+    approval = client.decide_approval(
+        "55555555-5555-4555-8555-555555555555",
+        decision="approve",
+        comment="Looks good",
+        idempotency_key="approval-001",
+    )
+    print(approval["approval"]["decision"])
+    capabilities = client.get_capabilities()
+    print(capabilities["supported_intent_types"])
     subscription = client.upsert_webhook_subscription(
         {
             "callback_url": "https://integrator.example/webhooks/axme",

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -138,6 +138,30 @@ class AxmeClient:
             retryable=idempotency_key is not None,
         )
 
+    def decide_approval(
+        self,
+        approval_id: str,
+        *,
+        decision: str,
+        comment: str | None = None,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"decision": decision}
+        if comment is not None:
+            payload["comment"] = comment
+        return self._request_json(
+            "POST",
+            f"/v1/approvals/{approval_id}/decision",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def get_capabilities(self, *, trace_id: str | None = None) -> dict[str, Any]:
+        return self._request_json("GET", "/v1/capabilities", trace_id=trace_id, retryable=True)
+
     def upsert_webhook_subscription(
         self,
         payload: dict[str, Any],


### PR DESCRIPTION
## Summary
- add `decide_approval()` and `get_capabilities()` to the Python SDK client
- add SDK tests validating request paths, payloads, and idempotency header behavior
- extend quickstart examples so integrators can call the two newly covered families

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)