### PR TITLE
feat: add invites create/get/accept helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ with AxmeClient(config) as client:
     print(approval["approval"]["decision"])
     capabilities = client.get_capabilities()
     print(capabilities["supported_intent_types"])
+    invite = client.create_invite(
+        {"owner_agent": "agent://example/receiver", "recipient_hint": "Partner A", "ttl_seconds": 3600},
+        idempotency_key="invite-create-001",
+    )
+    print(invite["token"])
+    invite_details = client.get_invite(invite["token"])
+    print(invite_details["status"])
+    accepted = client.accept_invite(
+        invite["token"],
+        {"nick": "@PartnerA.User", "display_name": "Partner A"},
+        idempotency_key="invite-accept-001",
+    )
+    print(accepted["public_address"])
     subscription = client.upsert_webhook_subscription(
         {
             "callback_url": "https://integrator.example/webhooks/axme",

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -162,6 +162,42 @@ class AxmeClient:
     def get_capabilities(self, *, trace_id: str | None = None) -> dict[str, Any]:
         return self._request_json("GET", "/v1/capabilities", trace_id=trace_id, retryable=True)
 
+    def create_invite(
+        self,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            "/v1/invites/create",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def get_invite(self, token: str, *, trace_id: str | None = None) -> dict[str, Any]:
+        return self._request_json("GET", f"/v1/invites/{token}", trace_id=trace_id, retryable=True)
+
+    def accept_invite(
+        self,
+        token: str,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            f"/v1/invites/{token}/accept",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
     def upsert_webhook_subscription(
         self,
         payload: dict[str, Any],


### PR DESCRIPTION
## Summary
- add Python SDK methods for `invites.create`, `invites.get`, and `invites.accept`
- add request/response tests for all three invite endpoints
- extend quickstart with invite lifecycle example calls

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)