### PR TITLE
feat: add media upload helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ with AxmeClient(config) as client:
         idempotency_key="invite-accept-001",
     )
     print(accepted["public_address"])
+    media_upload = client.create_media_upload(
+        {
+            "owner_agent": "agent://example/receiver",
+            "filename": "contract.pdf",
+            "mime_type": "application/pdf",
+            "size_bytes": 12345,
+        },
+        idempotency_key="media-create-001",
+    )
+    print(media_upload["upload_id"])
+    media_state = client.get_media_upload(media_upload["upload_id"])
+    print(media_state["upload"]["status"])
+    finalized = client.finalize_media_upload(
+        {"upload_id": media_upload["upload_id"], "size_bytes": 12345},
+        idempotency_key="media-finalize-001",
+    )
+    print(finalized["status"])
     subscription = client.upsert_webhook_subscription(
         {
             "callback_url": "https://integrator.example/webhooks/axme",

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -198,6 +198,41 @@ class AxmeClient:
             retryable=idempotency_key is not None,
         )
 
+    def create_media_upload(
+        self,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            "/v1/media/create-upload",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def get_media_upload(self, upload_id: str, *, trace_id: str | None = None) -> dict[str, Any]:
+        return self._request_json("GET", f"/v1/media/{upload_id}", trace_id=trace_id, retryable=True)
+
+    def finalize_media_upload(
+        self,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            "/v1/media/finalize-upload",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
     def upsert_webhook_subscription(
         self,
         payload: dict[str, Any],


### PR DESCRIPTION
## Summary
- add `create_media_upload()`, `get_media_upload()`, and `finalize_media_upload()` to the Python SDK client
- add request/response tests for media upload lifecycle calls
- extend quickstart examples with media create/get/finalize usage

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)