### PR TITLE
feat: add schema upsert and get helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ with AxmeClient(config) as client:
         idempotency_key="media-finalize-001",
     )
     print(finalized["status"])
+    schema = client.upsert_schema(
+        {
+            "semantic_type": "axme.calendar.schedule.v1",
+            "schema_json": {"type": "object", "required": ["date"], "properties": {"date": {"type": "string"}}},
+            "compatibility_mode": "strict",
+        },
+        idempotency_key="schema-upsert-001",
+    )
+    print(schema["schema"]["schema_hash"])
+    schema_get = client.get_schema("axme.calendar.schedule.v1")
+    print(schema_get["schema"]["semantic_type"])
     subscription = client.upsert_webhook_subscription(
         {
             "callback_url": "https://integrator.example/webhooks/axme",

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -233,6 +233,25 @@ class AxmeClient:
             retryable=idempotency_key is not None,
         )
 
+    def upsert_schema(
+        self,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            "/v1/schemas",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def get_schema(self, semantic_type: str, *, trace_id: str | None = None) -> dict[str, Any]:
+        return self._request_json("GET", f"/v1/schemas/{semantic_type}", trace_id=trace_id, retryable=True)
+
     def upsert_webhook_subscription(
         self,
         payload: dict[str, Any],


### PR DESCRIPTION
## Summary
- add `upsert_schema()` and `get_schema()` client helpers to the Python SDK
- add schema family request/response tests for upsert and get flows
- extend quickstart with schema registry usage examples

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)