### PR TITLE
feat: add users profile and nick helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,25 @@ with AxmeClient(config) as client:
     print(schema["schema"]["schema_hash"])
     schema_get = client.get_schema("axme.calendar.schedule.v1")
     print(schema_get["schema"]["semantic_type"])
+    registered = client.register_nick(
+        {"nick": "@partner.user", "display_name": "Partner User"},
+        idempotency_key="nick-register-001",
+    )
+    print(registered["owner_agent"])
+    nick_check = client.check_nick("@partner.user")
+    print(nick_check["available"])
+    renamed = client.rename_nick(
+        {"owner_agent": registered["owner_agent"], "nick": "@partner.new"},
+        idempotency_key="nick-rename-001",
+    )
+    print(renamed["public_address"])
+    profile = client.get_user_profile(registered["owner_agent"])
+    print(profile["updated_at"])
+    profile_updated = client.update_user_profile(
+        {"owner_agent": registered["owner_agent"], "display_name": "Partner User Updated"},
+        idempotency_key="profile-update-001",
+    )
+    print(profile_updated["display_name"])
     subscription = client.upsert_webhook_subscription(
         {
             "callback_url": "https://integrator.example/webhooks/axme",

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -252,6 +252,66 @@ class AxmeClient:
     def get_schema(self, semantic_type: str, *, trace_id: str | None = None) -> dict[str, Any]:
         return self._request_json("GET", f"/v1/schemas/{semantic_type}", trace_id=trace_id, retryable=True)
 
+    def register_nick(
+        self,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            "/v1/users/register-nick",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def check_nick(self, nick: str, *, trace_id: str | None = None) -> dict[str, Any]:
+        return self._request_json("GET", "/v1/users/check-nick", params={"nick": nick}, trace_id=trace_id, retryable=True)
+
+    def rename_nick(
+        self,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            "/v1/users/rename-nick",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def get_user_profile(self, owner_agent: str, *, trace_id: str | None = None) -> dict[str, Any]:
+        return self._request_json(
+            "GET",
+            "/v1/users/profile",
+            params={"owner_agent": owner_agent},
+            trace_id=trace_id,
+            retryable=True,
+        )
+
+    def update_user_profile(
+        self,
+        payload: dict[str, Any],
+        *,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return self._request_json(
+            "POST",
+            "/v1/users/profile/update",
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
     def upsert_webhook_subscription(
         self,
         payload: dict[str, Any],


### PR DESCRIPTION
## Summary
- add `register_nick`, `check_nick`, `rename_nick`, `get_user_profile`, and `update_user_profile` methods
- add unit tests for all users family operations and request wiring
- extend quickstart examples with users nick/profile lifecycle usage

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)