### PR TITLE
feat: add intents get and inbox action helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ with AxmeClient(config) as client:
         idempotency_key="create-intent-001",
     )
     print(result)
+    print(client.get_intent(result["intent_id"])["intent"]["status"])
     inbox = client.list_inbox(owner_agent="agent://example/receiver", trace_id="trace-inbox-001")
     print(inbox)
+    thread = client.get_inbox_thread("11111111-1111-4111-8111-111111111111", owner_agent="agent://example/receiver")
+    print(thread["thread"]["status"])
     changes = client.list_inbox_changes(owner_agent="agent://example/receiver", limit=50)
     print(changes["next_cursor"], changes["has_more"])
     replied = client.reply_inbox_thread(
@@ -42,6 +45,34 @@ with AxmeClient(config) as client:
         idempotency_key="reply-001",
     )
     print(replied)
+    delegated = client.delegate_inbox_thread(
+        "11111111-1111-4111-8111-111111111111",
+        {"delegate_to": "agent://example/delegate", "note": "handoff"},
+        owner_agent="agent://example/receiver",
+        idempotency_key="delegate-001",
+    )
+    print(delegated["thread"]["status"])
+    approved = client.approve_inbox_thread(
+        "11111111-1111-4111-8111-111111111111",
+        {"comment": "approved"},
+        owner_agent="agent://example/receiver",
+        idempotency_key="approve-001",
+    )
+    print(approved["thread"]["status"])
+    rejected = client.reject_inbox_thread(
+        "11111111-1111-4111-8111-111111111111",
+        {"comment": "rejected"},
+        owner_agent="agent://example/receiver",
+        idempotency_key="reject-001",
+    )
+    print(rejected["thread"]["status"])
+    deleted = client.delete_inbox_messages(
+        "11111111-1111-4111-8111-111111111111",
+        {"mode": "self", "limit": 1},
+        owner_agent="agent://example/receiver",
+        idempotency_key="delete-001",
+    )
+    print(deleted["deleted_count"])
     approval = client.decide_approval(
         "55555555-5555-4555-8555-555555555555",
         decision="approve",

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -75,6 +75,9 @@ class AxmeClient:
             retryable=idempotency_key is not None,
         )
 
+    def get_intent(self, intent_id: str, *, trace_id: str | None = None) -> dict[str, Any]:
+        return self._request_json("GET", f"/v1/intents/{intent_id}", trace_id=trace_id, retryable=True)
+
     def list_inbox(self, *, owner_agent: str | None = None, trace_id: str | None = None) -> dict[str, Any]:
         params: dict[str, str] | None = None
         if owner_agent is not None:
@@ -133,6 +136,94 @@ class AxmeClient:
             f"/v1/inbox/{thread_id}/reply",
             params=params,
             json_body={"message": message},
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def delegate_inbox_thread(
+        self,
+        thread_id: str,
+        payload: dict[str, Any],
+        *,
+        owner_agent: str | None = None,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] | None = None
+        if owner_agent is not None:
+            params = {"owner_agent": owner_agent}
+        return self._request_json(
+            "POST",
+            f"/v1/inbox/{thread_id}/delegate",
+            params=params,
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def approve_inbox_thread(
+        self,
+        thread_id: str,
+        payload: dict[str, Any],
+        *,
+        owner_agent: str | None = None,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] | None = None
+        if owner_agent is not None:
+            params = {"owner_agent": owner_agent}
+        return self._request_json(
+            "POST",
+            f"/v1/inbox/{thread_id}/approve",
+            params=params,
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def reject_inbox_thread(
+        self,
+        thread_id: str,
+        payload: dict[str, Any],
+        *,
+        owner_agent: str | None = None,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] | None = None
+        if owner_agent is not None:
+            params = {"owner_agent": owner_agent}
+        return self._request_json(
+            "POST",
+            f"/v1/inbox/{thread_id}/reject",
+            params=params,
+            json_body=payload,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            retryable=idempotency_key is not None,
+        )
+
+    def delete_inbox_messages(
+        self,
+        thread_id: str,
+        payload: dict[str, Any],
+        *,
+        owner_agent: str | None = None,
+        idempotency_key: str | None = None,
+        trace_id: str | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, str] | None = None
+        if owner_agent is not None:
+            params = {"owner_agent": owner_agent}
+        return self._request_json(
+            "POST",
+            f"/v1/inbox/{thread_id}/messages/delete",
+            params=params,
+            json_body=payload,
             idempotency_key=idempotency_key,
             trace_id=trace_id,
             retryable=idempotency_key is not None,


### PR DESCRIPTION
## Summary
- add `get_intent` plus inbox delegate/approve/reject/message-delete helpers to Python GA SDK
- extend unit tests to validate all new request paths, payloads, and owner scope wiring
- update quickstart with intents.get and remaining inbox family examples

## Test plan
- [x] `/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python -m pytest -q`

Made with [Cursor](https://cursor.com)