### PR TITLE
feat: add MCP tool-adapter helpers to Python SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Official Python SDK for Axme APIs and workflows.
 
+Canonical protocol positioning:
+
+- **AXP is the Intent Protocol (durable execution layer).**
+
 ## Status
 
 Initial v1 skeleton in progress.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ with AxmeClient(config) as client:
         owner_agent="agent://example/receiver",
     )
     print(events["event_id"])
+    mcp_info = client.mcp_initialize()
+    print(mcp_info["protocolVersion"])
+    tools = client.mcp_list_tools()
+    print(len(tools.get("tools", [])))
+    mcp_result = client.mcp_call_tool(
+        "axme.send",
+        arguments={"to": "agent://example/receiver", "text": "hello from MCP"},
+        owner_agent="agent://example/receiver",
+        idempotency_key="mcp-send-001",
+    )
+    print(mcp_result.get("status"))
 ```
 
 ## Development


### PR DESCRIPTION
## Summary
- add `mcp_initialize`, `mcp_list_tools`, and `mcp_call_tool` to `AxmeClient`
- add schema-aware argument validation, owner propagation, retry semantics, and observer hooks for MCP flows
- extend SDK tests and README quickstart with MCP usage coverage

## Test plan
- [x] `"/home/georgebelsky/axme-workspace/.local-internal/.venv/bin/python" -m pytest`

Made with [Cursor](https://cursor.com)