### PR TITLE
docs: align alpha access URL and contact wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Official Python SDK for the AXME platform.** Send and manage intents, observe lifecycle events, work with inbox and approvals, and access the full enterprise admin surface — all from idiomatic Python.
 
 > **Alpha** · API surface is stabilizing. Not recommended for production workloads yet.  
-> Bug reports, feedback, and alpha access → [hello@axme.ai](mailto:hello@axme.ai)
+> Alpha access: https://cloud.axme.ai/alpha · Contact and suggestions: [hello@axme.ai](mailto:hello@axme.ai)
 
 ---
 
@@ -198,6 +198,6 @@ axme-sdk-python/
 ## Contributing & Contact
 
 - Bug reports and feature requests: open an issue in this repository
-- Alpha program access and integration questions: [hello@axme.ai](mailto:hello@axme.ai)
+- Alpha access: https://cloud.axme.ai/alpha · Contact and suggestions: [hello@axme.ai](mailto:hello@axme.ai)
 - Security disclosures: see [SECURITY.md](SECURITY.md)
 - Contribution guidelines: [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- Update README alpha-access wording to use https://cloud.axme.ai/alpha.
- Keep hello@axme.ai as the contact channel for suggestions and communication.

## Test plan
- [x] Verify README alpha-access lines point to https://cloud.axme.ai/alpha.
- [x] Verify hello@axme.ai remains for contact/suggestions.
