### PR TITLE
docs: switch Python install command to published package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ The AXME Python SDK gives you a fully typed client for the AXME platform. You ca
 ## Install
 
 ```bash
-python -m pip install "git+https://github.com/AxmeAI/axme-sdk-python.git"
+pip install axme
 ```
 
-PyPI publication target: `axme` (pending registry credentials and first public release).
 For local development from source:
 
 ```bash


### PR DESCRIPTION
## Summary
- replace Git install command with `pip install axme` in the Python SDK README
- remove the now-obsolete pending-publication note
- keep source install instructions for local development

## Test plan
- [x] `python -m pip install --dry-run axme`
- [ ] CI check on this PR

Made with [Cursor](https://cursor.com)