### PR TITLE
feat: release Python SDK 0.1.1 auth and packaging updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,43 @@
 
 ---
 
+## What Is AXME?
+
+AXME is a coordination infrastructure for durable execution of long-running intents across distributed systems.
+
+It provides a model for executing **intents** — requests that may take minutes, hours, or longer to complete — across services, agents, and human participants.
+
+## AXP — the Intent Protocol
+
+At the core of AXME is **AXP (Intent Protocol)** — an open protocol that defines contracts and lifecycle rules for intent processing.
+
+AXP can be implemented independently.  
+The open part of the platform includes:
+
+- the protocol specification and schemas
+- SDKs and CLI for integration
+- conformance tests
+- implementation and integration documentation
+
+## AXME Cloud
+
+**AXME Cloud** is the managed service that runs AXP in production together with **The Registry** (identity and routing).
+
+It removes operational complexity by providing:
+
+- reliable intent delivery and retries  
+- lifecycle management for long-running operations  
+- handling of timeouts, waits, reminders, and escalation  
+- observability of intent status and execution history  
+
+State and events can be accessed through:
+
+- API and SDKs  
+- event streams and webhooks  
+- the cloud console
+
+---
+
 ## What You Can Do With This SDK
 
 The AXME Python SDK gives you a fully typed client for the AXME platform. You can:
@@ -25,6 +62,8 @@ The AXME Python SDK gives you a fully typed client for the AXME platform. You ca
 pip install axme
 ```
 
+Primary import path is `axme` (legacy `axme_sdk` remains as compatibility alias).
+
 For local development from source:
 
 ```bash
@@ -36,12 +75,13 @@ python -m pip install -e ".[dev]"
 ## Quickstart
 
 ```python
-from axme_sdk import AxmeClient, AxmeClientConfig
+from axme import AxmeClient, AxmeClientConfig
 
 client = AxmeClient(
     AxmeClientConfig(
         base_url="https://gateway.axme.ai",
-        api_key="YOUR_API_KEY",
+        api_key="YOUR_PLATFORM_API_KEY",  # sent as x-api-key
+        actor_token="OPTIONAL_USER_OR_SESSION_TOKEN",  # sent as Authorization: Bearer
     )
 )
 
@@ -178,6 +218,9 @@ pytest
 
 ```
 axme-sdk-python/
+├── axme/
+│   ├── client.py              # Canonical public import path
+│   └── exceptions.py          # Canonical exception import path
 ├── axme_sdk/
 │   ├── client.py              # AxmeClient — all API methods
 │   ├── config.py              # AxmeClientConfig

--- a/axme/__init__.py
+++ b/axme/__init__.py
@@ -1,0 +1,20 @@
+from axme_sdk import AxmeClient, AxmeClientConfig
+from axme_sdk.exceptions import (
+    AxmeAuthError,
+    AxmeError,
+    AxmeHttpError,
+    AxmeRateLimitError,
+    AxmeServerError,
+    AxmeValidationError,
+)
+
+__all__ = [
+    "AxmeClient",
+    "AxmeClientConfig",
+    "AxmeAuthError",
+    "AxmeError",
+    "AxmeHttpError",
+    "AxmeRateLimitError",
+    "AxmeServerError",
+    "AxmeValidationError",
+]

--- a/axme/client.py
+++ b/axme/client.py
@@ -1,0 +1,3 @@
+from axme_sdk.client import AxmeClient, AxmeClientConfig
+
+__all__ = ["AxmeClient", "AxmeClientConfig"]

--- a/axme/exceptions.py
+++ b/axme/exceptions.py
@@ -1,0 +1,17 @@
+from axme_sdk.exceptions import (
+    AxmeAuthError,
+    AxmeError,
+    AxmeHttpError,
+    AxmeRateLimitError,
+    AxmeServerError,
+    AxmeValidationError,
+)
+
+__all__ = [
+    "AxmeAuthError",
+    "AxmeError",
+    "AxmeHttpError",
+    "AxmeRateLimitError",
+    "AxmeServerError",
+    "AxmeValidationError",
+]

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -21,6 +21,8 @@ from .exceptions import (
 class AxmeClientConfig:
     base_url: str
     api_key: str
+    actor_token: str | None = None
+    bearer_token: str | None = None
     timeout_seconds: float = 15.0
     max_retries: int = 2
     retry_backoff_seconds: float = 0.2
@@ -30,6 +32,12 @@ class AxmeClientConfig:
     mcp_protocol_version: str = "2024-11-05"
     mcp_observer: Callable[[dict[str, Any]], None] | None = None
 
+    def __post_init__(self) -> None:
+        if self.actor_token and self.bearer_token and self.actor_token != self.bearer_token:
+            raise ValueError("actor_token and bearer_token must match when both are provided")
+        if self.actor_token is None and self.bearer_token is not None:
+            object.__setattr__(self, "actor_token", self.bearer_token)
+
 
 class AxmeClient:
     def __init__(self, config: AxmeClientConfig, *, http_client: httpx.Client | None = None) -> None:
@@ -38,10 +46,7 @@ class AxmeClient:
         self._http = http_client or httpx.Client(
             base_url=self._config.base_url.rstrip("/"),
             timeout=self._config.timeout_seconds,
-            headers={
-                "Authorization": f"Bearer {self._config.api_key}",
-                "Content-Type": "application/json",
-            },
+            headers=self._default_headers(),
         )
         self._mcp_tool_schemas: dict[str, dict[str, Any]] = {}
 
@@ -1626,6 +1631,15 @@ class AxmeClient:
         if observer is None:
             return
         observer(event)
+
+    def _default_headers(self) -> dict[str, str]:
+        headers = {
+            "x-api-key": self._config.api_key,
+            "Content-Type": "application/json",
+        }
+        if self._config.actor_token:
+            headers["Authorization"] = f"Bearer {self._config.actor_token}"
+        return headers
 
     def _sleep_before_retry(self, attempt_idx: int, *, retry_after: int | None) -> None:
         if retry_after is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axme"
-version = "0.1.0"
+version = "0.1.1"
 description = "Official Python SDK for Axme APIs."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -16,7 +16,7 @@ dependencies = ["httpx>=0.27.0,<1.0.0"]
 dev = ["pytest>=9.0.0,<10.0.0"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["axme_sdk"]
+packages = ["axme", "axme_sdk"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,8 +5,8 @@ import json
 import httpx
 import pytest
 
-from axme_sdk import AxmeClient, AxmeClientConfig
-from axme_sdk.exceptions import AxmeAuthError, AxmeHttpError, AxmeRateLimitError, AxmeValidationError
+from axme import AxmeClient, AxmeClientConfig
+from axme.exceptions import AxmeAuthError, AxmeHttpError, AxmeRateLimitError, AxmeValidationError
 
 
 def _transport(handler):
@@ -17,6 +17,8 @@ def _client(
     handler,
     api_key: str = "token",
     *,
+    actor_token: str | None = None,
+    bearer_token: str | None = None,
     max_retries: int = 2,
     retry_backoff_seconds: float = 0.0,
     auto_trace_id: bool = True,
@@ -24,17 +26,22 @@ def _client(
     cfg = AxmeClientConfig(
         base_url="https://api.axme.test",
         api_key=api_key,
+        actor_token=actor_token,
+        bearer_token=bearer_token,
         max_retries=max_retries,
         retry_backoff_seconds=retry_backoff_seconds,
         auto_trace_id=auto_trace_id,
     )
+    default_headers = {
+        "x-api-key": cfg.api_key,
+        "Content-Type": "application/json",
+    }
+    if cfg.actor_token:
+        default_headers["Authorization"] = f"Bearer {cfg.actor_token}"
     http_client = httpx.Client(
         transport=_transport(handler),
         base_url=cfg.base_url,
-        headers={
-            "Authorization": f"Bearer {cfg.api_key}",
-            "Content-Type": "application/json",
-        },
+        headers=default_headers,
     )
     return AxmeClient(cfg, http_client=http_client)
 
@@ -80,7 +87,7 @@ def test_health_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "GET"
         assert request.url.path == "/health"
-        assert request.headers["Authorization"] == "Bearer token"
+        assert request.headers["x-api-key"] == "token"
         return httpx.Response(200, json={"ok": True})
 
     client = _client(handler)
@@ -94,6 +101,26 @@ def test_health_propagates_trace_id_header() -> None:
 
     client = _client(handler, auto_trace_id=False)
     assert client.health(trace_id="trace-123") == {"ok": True}
+
+
+def test_health_includes_actor_token_authorization_when_configured() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-api-key"] == "platform-key"
+        assert request.headers["authorization"] == "Bearer actor-token"
+        return httpx.Response(200, json={"ok": True})
+
+    client = _client(handler, api_key="platform-key", actor_token="actor-token")
+    assert client.health() == {"ok": True}
+
+
+def test_client_config_rejects_conflicting_actor_token_aliases() -> None:
+    with pytest.raises(ValueError, match="actor_token and bearer_token must match"):
+        AxmeClientConfig(
+            base_url="https://api.axme.test",
+            api_key="platform-key",
+            actor_token="token-a",
+            bearer_token="token-b",
+        )
 
 
 def test_create_intent_success() -> None:
@@ -487,7 +514,7 @@ def test_reply_inbox_thread_success() -> None:
         assert request.url.path == f"/v1/inbox/{thread_id}/reply"
         assert request.url.params.get("owner_agent") == "agent://owner"
         assert request.headers["idempotency-key"] == "reply-1"
-        assert request.read() == b'{"message":"ack"}'
+        assert json.loads(request.read().decode("utf-8")) == {"message": "ack"}
         return httpx.Response(200, json={"ok": True, "thread": thread})
 
     client = _client(handler)
@@ -631,7 +658,10 @@ def test_decide_approval_success() -> None:
         assert request.method == "POST"
         assert request.url.path == f"/v1/approvals/{approval_id}/decision"
         assert request.headers["idempotency-key"] == "approval-1"
-        assert request.read() == b'{"decision":"approve","comment":"approved"}'
+        assert json.loads(request.read().decode("utf-8")) == {
+            "decision": "approve",
+            "comment": "approved",
+        }
         return httpx.Response(
             200,
             json={
@@ -1323,7 +1353,7 @@ def test_upsert_webhook_subscription_success() -> None:
         assert request.method == "POST"
         assert request.url.path == "/v1/webhooks/subscriptions"
         assert request.headers["idempotency-key"] == "wh-1"
-        assert request.read() == b'{"callback_url":"https://integrator.example/webhooks/axme","event_types":["inbox.thread_created"],"active":true}'
+        assert json.loads(request.read().decode("utf-8")) == request_payload
         return httpx.Response(200, json={"ok": True, "subscription": subscription})
 
     client = _client(handler)
@@ -1555,7 +1585,7 @@ def test_mcp_list_tools_and_call_tool_with_schema_validation() -> None:
         transport=_transport(handler),
         base_url=cfg.base_url,
         headers={
-            "Authorization": f"Bearer {cfg.api_key}",
+            "x-api-key": cfg.api_key,
             "Content-Type": "application/json",
         },
     )


### PR DESCRIPTION
## Summary
- bump and align Python SDK to the 0.1.1 auth/packaging surface
- add canonical `axme` import package while preserving compatibility with `axme_sdk`
- update README/install/auth semantics to platform key + actor token model

## Test plan
- [x] `pytest -q`
- [ ] Required GitHub checks on this PR

Made with [Cursor](https://cursor.com)