### PR TITLE
feat: add cloud-first defaults and minimal Python quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ from axme import AxmeClient, AxmeClientConfig
 
 client = AxmeClient(
     AxmeClientConfig(
-        base_url="https://gateway.axme.ai",
-        api_key="YOUR_PLATFORM_API_KEY",  # sent as x-api-key
+        api_key="AXME_API_KEY",  # sent as x-api-key
         actor_token="OPTIONAL_USER_OR_SESSION_TOKEN",  # sent as Authorization: Bearer
+        # Optional override (defaults to https://api.cloud.axme.ai):
+        # base_url="https://staging-api.cloud.axme.ai",
     )
 )
 
@@ -103,6 +104,26 @@ print(intent["intent_id"], intent["status"])
 resolved = client.wait_for(intent["intent_id"], terminal_states={"RESOLVED", "CANCELLED"})
 print(resolved["status"])
 ```
+
+---
+
+## Minimal Language-Native Example
+
+Short basic submit/get example (about 25 lines):
+
+- [`examples/basic_submit.py`](examples/basic_submit.py)
+
+Run:
+
+```bash
+export AXME_API_KEY="axme_sa_..."
+python examples/basic_submit.py
+```
+
+Full runnable scenario set lives in:
+
+- Cloud: <https://github.com/AxmeAI/axme-examples/tree/main/cloud>
+- Protocol-only: <https://github.com/AxmeAI/axme-examples/tree/main/protocol>
 
 ---
 
@@ -226,6 +247,8 @@ axme-sdk-python/
 │   ├── config.py              # AxmeClientConfig
 │   └── exceptions.py          # AxmeAPIError and subclasses
 ├── tests/                     # Unit and integration tests
+├── examples/
+│   └── basic_submit.py        # Minimal language-native quickstart
 └── docs/
     └── diagrams/              # Diagram copies for README embedding
 ```

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -17,10 +17,13 @@ from .exceptions import (
 )
 
 
+DEFAULT_BASE_URL = "https://api.cloud.axme.ai"
+
+
 @dataclass(frozen=True)
 class AxmeClientConfig:
-    base_url: str
-    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    api_key: str = ""
     actor_token: str | None = None
     bearer_token: str | None = None
     timeout_seconds: float = 15.0
@@ -33,6 +36,10 @@ class AxmeClientConfig:
     mcp_observer: Callable[[dict[str, Any]], None] | None = None
 
     def __post_init__(self) -> None:
+        if not self.base_url or not self.base_url.strip():
+            raise ValueError("base_url must be a non-empty string")
+        if not self.api_key or not self.api_key.strip():
+            raise ValueError("api_key must be a non-empty string")
         if self.actor_token and self.bearer_token and self.actor_token != self.bearer_token:
             raise ValueError("actor_token and bearer_token must match when both are provided")
         if self.actor_token is None and self.bearer_token is not None:

--- a/examples/basic_submit.py
+++ b/examples/basic_submit.py
@@ -1,0 +1,34 @@
+import os
+from uuid import uuid4
+
+from axme import AxmeClient, AxmeClientConfig
+
+
+def main() -> None:
+    client = AxmeClient(
+        AxmeClientConfig(
+            api_key=os.environ["AXME_API_KEY"],
+            base_url=os.getenv("AXME_BASE_URL", "https://api.cloud.axme.ai"),
+        )
+    )
+    correlation_id = str(uuid4())
+    created = client.create_intent(
+        {
+            "intent_type": "intent.demo.v1",
+            "from_agent": "agent://basic/python/source",
+            "to_agent": "agent://basic/python/target",
+            "payload": {"task": "hello-from-python"},
+        },
+        correlation_id=correlation_id,
+    )
+    intent_id = str(created["intent_id"])
+    current = client.get_intent(intent_id)
+    intent = current.get("intent") if isinstance(current, dict) else None
+    if isinstance(intent, dict):
+        print(intent.get("status") or intent.get("lifecycle_status"))
+    else:
+        print(current.get("status") if isinstance(current, dict) else "UNKNOWN")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -123,6 +123,11 @@ def test_client_config_rejects_conflicting_actor_token_aliases() -> None:
         )
 
 
+def test_client_config_uses_default_base_url_when_not_provided() -> None:
+    cfg = AxmeClientConfig(api_key="platform-key")
+    assert cfg.base_url == "https://api.cloud.axme.ai"
+
+
 def test_create_intent_success() -> None:
     payload = {
         "intent_type": "notify.message.v1",


### PR DESCRIPTION
## Summary
- default `AxmeClientConfig.base_url` to `https://api.cloud.axme.ai`
- enforce non-empty `api_key` and `base_url` in client config validation
- add a minimal `examples/basic_submit.py` quickstart and link README guidance to `axme-examples` for full runnable flows

## Test plan
- [x] `python -m pytest tests/test_client.py`
- [x] live run: `AXME_API_KEY=... AXME_BASE_URL=https://api.cloud.axme.ai python examples/basic_submit.py`

Made with [Cursor](https://cursor.com)