### PR TITLE
docs: add MCP client usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,33 @@ The SDK docs folder contains diagrams for the API patterns used by this client:
 
 ---
 
+## MCP (Model Context Protocol)
+
+The Python SDK includes a built-in MCP endpoint client for gateway-hosted MCP sessions:
+
+```python
+# Initialize an MCP session
+init = client.mcp_initialize()
+print(init["serverInfo"])
+
+# List available tools
+tools = client.mcp_list_tools()
+for tool in tools.get("tools", []):
+    print(tool["name"])
+
+# Call a tool
+result = client.mcp_call_tool("create_intent", arguments={
+    "intent_type": "order.fulfillment.v1",
+    "payload": {"order_id": "ord_123"},
+    "owner_agent": "agent://fulfillment-service",
+})
+print(result)
+```
+
+MCP calls go to `/mcp` by default. Override with `mcp_endpoint_path` in `AxmeClientConfig`.
+
+---
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary
- Document mcp_initialize, mcp_list_tools, mcp_call_tool methods which are fully implemented and tested but were not mentioned in the README
- Add note about default endpoint path and config override

## Test plan
- [ ] Methods exist in axme_sdk/client.py (mcp_initialize, mcp_list_tools, mcp_call_tool)

Made with [Cursor](https://cursor.com)