### PR TITLE
chore: bump to 0.1.2 + add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.1.2 (2026-03-18)
+
+### Bug Fixes
+- Fix `ResponseNotRead` crash when SSE streaming encounters HTTP 503 error
+
+### Features
+- `listen()` now accepts optional `status` parameter to filter intents by lifecycle status
+- Default SSE stream excludes terminal statuses (COMPLETED, FAILED, CANCELED, TIMED_OUT) — agents no longer receive zombie intents
+
+## 0.1.1 (2026-03-13)
+
+- Initial alpha release with full AXME API coverage (96 methods)
+- SSE streaming (`listen`, `observe`, `wait_for`)
+- Scenario API (`apply_scenario`, `validate_scenario`)
+- MCP protocol support (`mcp_initialize`, `mcp_list_tools`, `mcp_call_tool`)
+- Intent lifecycle, inbox, webhooks, admin APIs
+- Zero external dependencies beyond httpx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axme"
-version = "0.1.1"
+version = "0.1.2"
 description = "Official Python SDK for Axme APIs."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.1 → 0.1.2
- Add CHANGELOG.md

Changes since 0.1.1:
- SSE status filter on `listen()` — default-excludes terminal statuses (zombie fix)
- Fix `ResponseNotRead` crash on SSE 503 error

## Test plan
- [ ] `python -m pytest tests/ -v` passes
- [ ] Synchronized release with all SDKs

🤖 Generated with [Claude Code](https://claude.com/claude-code)