### PR TITLE
docs: add 8 human task types to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Official Python SDK for the AXME platform.** Send and manage intents, observe lifecycle events, work with inbox and approvals, and access the full enterprise admin surface — all from idiomatic Python.
 
 > **Alpha** · API surface is stabilizing. Not recommended for production workloads yet.  
-> Alpha access: https://cloud.axme.ai/alpha · Contact and suggestions: [hello@axme.ai](mailto:hello@axme.ai)
+> **Alpha** — install CLI, log in, run your first example in under 5 minutes. [Quick Start](https://cloud.axme.ai/alpha/cli) · [hello@axme.ai](mailto:hello@axme.ai)
 
 ---
 
@@ -303,6 +303,6 @@ axme-sdk-python/
 ## Contributing & Contact
 
 - Bug reports and feature requests: open an issue in this repository
-- Alpha access: https://cloud.axme.ai/alpha · Contact and suggestions: [hello@axme.ai](mailto:hello@axme.ai)
+- Quick Start: https://cloud.axme.ai/alpha/cli · Contact: [hello@axme.ai](mailto:hello@axme.ai)
 - Security disclosures: see [SECURITY.md](SECURITY.md)
 - Contribution guidelines: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -181,7 +181,56 @@ for event in client.observe(intent["intent_id"]):
 
 ---
 
-## Approvals and Human-in-the-Loop
+## Human-in-the-Loop (8 Task Types)
+
+AXME supports 8 human task types. Each pauses the workflow and notifies a human via email with a link to a web task page.
+
+| Task type | Use case | Default outcomes |
+|-----------|----------|-----------------|
+| `approval` | Approve or reject a request | approved, rejected |
+| `confirmation` | Confirm a real-world action completed | confirmed, denied |
+| `review` | Review content with multiple outcomes | approved, changes_requested, rejected |
+| `assignment` | Assign work to a person or team | assigned, declined |
+| `form` | Collect structured data via form fields | submitted |
+| `clarification` | Request clarification (comment required) | provided, declined |
+| `manual_action` | Physical task completion (evidence required) | completed, failed |
+| `override` | Override a policy gate (comment required) | override_approved, rejected |
+
+```python
+# Create an intent with a human task step
+result = client.create_intent(
+    intent_type="intent.budget.approval.v1",
+    to_agent="agent://agent_core",
+    payload={"amount": 32000, "department": "engineering"},
+    human_task={
+        "title": "Approve Q3 budget",
+        "description": "Review and approve the Q3 infrastructure budget.",
+        "task_type": "approval",
+        "notify_email": "approver@example.com",
+        "allowed_outcomes": ["approved", "rejected"],
+    },
+)
+```
+
+Task types with forms use `form_schema` to define required fields:
+
+```python
+human_task={
+    "title": "Assign incident commander",
+    "task_type": "assignment",
+    "notify_email": "oncall@example.com",
+    "form_schema": {
+        "type": "object",
+        "required": ["assignee"],
+        "properties": {
+            "assignee": {"type": "string", "title": "Commander name"},
+            "priority": {"type": "string", "enum": ["P1", "P2", "P3"]},
+        },
+    },
+}
+```
+
+### Programmatic approvals (inbox API)
 
 ```python
 # Fetch pending approvals for an agent
@@ -191,7 +240,6 @@ for item in pending.get("items", []):
     thread_id = item.get("thread_id")
     if not thread_id:
         continue
-    # Approve the inbox thread with a note
     client.approve_inbox_thread(
         thread_id,
         {"note": "LGTM"},


### PR DESCRIPTION
## Summary
- Add "Human-in-the-Loop (8 Task Types)" section with task type table
- Add code examples for creating intents with human_task config
- Add form_schema example for assignment type
- Reorganize existing inbox approval example under subheading