### PR TITLE
Enhance AxmeAuthError messages for status codes 401 and 403

### DIFF
--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -1939,12 +1939,12 @@ class AxmeClient:
         if status_code == 401:
             raise AxmeAuthError(
                 status_code,
-                "Invalid API key. Please check your AXME_API_KEY.",
+                f"API key invalid - check AXME_API_KEY or run `axme login`. Server: {message}"
                 **kwargs)
         if status_code == 403:
             raise AxmeAuthError(
                 status_code,
-                "Access denied. You do not have permission to perform this action.",
+                f"Access denied. Check permissions. Server: {message}"
                 **kwargs)
         if status_code in (400, 409, 413, 422):
             raise AxmeValidationError(status_code, message, **kwargs)

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -1936,8 +1936,16 @@ class AxmeClient:
             "retry_after": retry_after,
         }
         status_code = response.status_code
-        if status_code in (401, 403):
-            raise AxmeAuthError(status_code, message, **kwargs)
+        if status_code == 401:
+            raise AxmeAuthError(
+                status_code,
+                "Invalid API key. Please check your AXME_API_KEY.",
+                **kwargs)
+        if status_code == 403:
+            raise AxmeAuthError(
+                status_code,
+                "Access denied. You do not have permission to perform this action.",
+                **kwargs)
         if status_code in (400, 409, 413, 422):
             raise AxmeValidationError(status_code, message, **kwargs)
         if status_code == 429:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1886,7 +1886,6 @@ def test_listen_requires_api_key() -> None:
     result = next(client.listen("org/ws/bot"))
     assert result["intent_id"] == "x1"
 
-
 def test_listen_raises_auth_error_on_401() -> None:
     from axme.exceptions import AxmeAuthError
 
@@ -1896,3 +1895,14 @@ def test_listen_raises_auth_error_on_401() -> None:
     client = _client(handler)
     with pytest.raises(AxmeAuthError):
         list(client.listen("org/ws/bot"))
+        
+def test_401_error_message_contains_hint_and_server_message():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"message": "API key expired"})
+    client = _client(handler)
+    with pytest.raises(AxmeAuthError) as exc_info:
+        client.health()
+    msg = str(exc_info.value)
+    assert "API key invalid" in msg
+    assert "API key expired" in msg
+        


### PR DESCRIPTION
This PR improves error messages for authentication failures.

- 401: Invalid API key (clear message added)
- 403: Access denied (permission issue clarified)

This improves developer experience by providing more meaningful feedback.