### PR TITLE
Add missing cross-SDK links to Related Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ axme-sdk-python/
 | [axme-examples](https://github.com/AxmeAI/axme-examples) | Runnable examples using this SDK |
 | [axme-sdk-typescript](https://github.com/AxmeAI/axme-sdk-typescript) | TypeScript equivalent |
 | [axme-sdk-go](https://github.com/AxmeAI/axme-sdk-go) | Go equivalent |
+| [axme-sdk-java](https://github.com/AxmeAI/axme-sdk-java) | Java equivalent |
+| [axme-sdk-dotnet](https://github.com/AxmeAI/axme-sdk-dotnet) | .NET equivalent |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add missing links to Java SDK (`axme-sdk-java`) and .NET SDK (`axme-sdk-dotnet`) in the Related Repositories table
- All 5 SDK READMEs now cross-link to each other consistently