### PR TITLE
fix: rename axme-spec references to axp-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ axme-sdk-python/
 | Repository | Role |
 |---|---|
 | [axme-docs](https://github.com/AxmeAI/axme-docs) | Full API reference and integration guides |
-| [axme-spec](https://github.com/AxmeAI/axme-spec) | Schema contracts this SDK implements |
+| [axp-spec](https://github.com/AxmeAI/axp-spec) | Schema contracts this SDK implements |
 | [axme-conformance](https://github.com/AxmeAI/axme-conformance) | Conformance suite that validates this SDK |
 | [axme-examples](https://github.com/AxmeAI/axme-examples) | Runnable examples using this SDK |
 | [axme-sdk-typescript](https://github.com/AxmeAI/axme-sdk-typescript) | TypeScript equivalent |


### PR DESCRIPTION
The axme-spec repo was renamed to axp-spec. Update all links.