### PR TITLE
release: v0.2.0 - Agent Mesh module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.2.0] - 2026-04-01
+
+### Added
+- **Agent Mesh module** - heartbeat, start_heartbeat (daemon thread), report_metric, list_agents, get_agent, kill, resume, list_events
+- Mesh module wired as `client.mesh` property (lazy init)
+- Dashboard URL: mesh.axme.ai
+
 ## 0.1.2 (2026-03-18)
 
 ### Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axme"
-version = "0.1.2"
+version = "0.2.0"
 description = "Official Python SDK for Axme APIs."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.2 to 0.2.0 in `pyproject.toml`
- Add v0.2.0 changelog entry: Agent Mesh module (heartbeat, start_heartbeat, report_metric, list_agents, get_agent, kill, resume, list_events), `client.mesh` lazy init, dashboard at mesh.axme.ai

## Post-merge
After merge, run:
```
git checkout main && git pull --ff-only origin main
git tag v0.2.0 && git push origin v0.2.0
```