### PR TITLE
feat: send X-Axme-Client header for AXME analytics

### DIFF
--- a/axme/__init__.py
+++ b/axme/__init__.py
@@ -1,4 +1,4 @@
-from axme_sdk import AxmeClient, AxmeClientConfig
+from axme_sdk import __version__, AxmeClient, AxmeClientConfig
 from axme_sdk.exceptions import (
     AxmeAuthError,
     AxmeError,
@@ -9,6 +9,7 @@ from axme_sdk.exceptions import (
 )
 
 __all__ = [
+    "__version__",
     "AxmeClient",
     "AxmeClientConfig",
     "AxmeAuthError",

--- a/axme_sdk/__init__.py
+++ b/axme_sdk/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.2.0"
+
 from .client import AxmeClient, AxmeClientConfig
 from .mesh import MeshClient
 from .exceptions import (
@@ -10,6 +12,7 @@ from .exceptions import (
 )
 
 __all__ = [
+    "__version__",
     "AxmeClient",
     "AxmeClientConfig",
     "MeshClient",

--- a/axme_sdk/client.py
+++ b/axme_sdk/client.py
@@ -1885,9 +1885,11 @@ class AxmeClient:
         observer(event)
 
     def _default_headers(self) -> dict[str, str]:
+        from . import __version__ as _sdk_version
         headers = {
             "x-api-key": self._config.api_key,
             "Content-Type": "application/json",
+            "X-Axme-Client": f"axme-sdk-python/{_sdk_version}",
         }
         if self._config.actor_token:
             headers["Authorization"] = f"Bearer {self._config.actor_token}"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,9 +32,11 @@ def _client(
         retry_backoff_seconds=retry_backoff_seconds,
         auto_trace_id=auto_trace_id,
     )
+    from axme import __version__ as _sdk_version
     default_headers = {
         "x-api-key": cfg.api_key,
         "Content-Type": "application/json",
+        "X-Axme-Client": f"axme-sdk-python/{_sdk_version}",
     }
     if cfg.actor_token:
         default_headers["Authorization"] = f"Bearer {cfg.actor_token}"
@@ -101,6 +103,19 @@ def test_health_propagates_trace_id_header() -> None:
 
     client = _client(handler, auto_trace_id=False)
     assert client.health(trace_id="trace-123") == {"ok": True}
+
+
+def test_health_sends_x_axme_client_header() -> None:
+    """Every outgoing request must carry X-Axme-Client: axme-sdk-python/<version>."""
+    from axme_sdk import __version__ as sdk_version
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        client_header = request.headers.get("x-axme-client", "")
+        assert client_header == f"axme-sdk-python/{sdk_version}", client_header
+        return httpx.Response(200, json={"ok": True})
+
+    client = _client(handler)
+    assert client.health() == {"ok": True}
 
 
 def test_health_includes_actor_token_authorization_when_configured() -> None:


### PR DESCRIPTION
## Summary
Adds `X-Axme-Client: axme-sdk-{lang}/{version}` header to all outgoing HTTP requests so the AXME platform admin dashboard can identify which SDK generated traffic. Per-org breakdown is exposed via `/admin/analytics/users/{org_id}/activity` `usage_breakdown.client_types` field on the control plane.

Without this header, all SDK requests show up as `unknown` in the admin user-detail page client breakdown panel.

## Changes
- New SDK version constant
- Header added in the request builder
- Unit test verifies the header is set on outgoing requests

## Test plan
- [x] Unit tests pass
- [ ] After merge + release, verify header appears in `api_usage_hourly.client_type` on staging